### PR TITLE
Fix some issues to render AnimeList

### DIFF
--- a/src/components/browse/list/AnimeCard.js
+++ b/src/components/browse/list/AnimeCard.js
@@ -1,24 +1,38 @@
 import Button from "../../shared/Button";
 import { Link } from "react-router-dom";
 
+const addFavorite = () => {
+  console.log("Has añadido esta película a favoritos");
+};
+
+const addWatched = () => {
+  console.log("Has añadido esta película a animes que ya has visto");
+};
+
+const addPending = () => {
+  console.log(
+    "Has añadido esta película a animes que quieres ver en un futuro"
+  );
+};
+
 const AnimeCard = (props) => {
   return (
     <>
       <Link
         to={`/anime/${props.anime.id}`}
         className='anime__link'
-        title={props.anime.title}
+        title={props.anime.titles.title}
       >
         <img
           src={props.anime.poster}
           className='anime__poster'
-          alt={props.anime.title}
+          alt={props.anime.titles.title}
         />
-        <h3 className='anime__title'>{props.anime.title}</h3>
-        <Button text='Favorite' />
-        <Button text='Watched' />
-        <Button text='Pending' />
+        <h3 className='anime__title'>{props.anime.titles.title}</h3>
       </Link>
+      <Button text='Favorite' handleClickButton={addFavorite} />
+      <Button text='Watched' handleClickButton={addWatched} />
+      <Button text='Pending' handleClickButton={addPending} />
     </>
   );
 };

--- a/src/components/browse/list/AnimeList.js
+++ b/src/components/browse/list/AnimeList.js
@@ -1,12 +1,13 @@
 import AnimeCard from "./AnimeCard";
 
 const AnimeList = (props) => {
+  console.log(props.animeData);
   // FUNCTIONS
   // Function to render the animes' list
   const renderAnimeList = props.animeData.map((anime) => (
-    <li className='anime' key={props.anime.id}>
+    <li className='anime' key={anime.id}>
       {/* Pass each object of the state of API array to the AnimeItem component with the props 'anime' */}
-      <AnimeCard animeData={props.animeData} />
+      <AnimeCard anime={anime} />
     </li>
   ));
 
@@ -14,7 +15,7 @@ const AnimeList = (props) => {
     <ul>
       {renderAnimeList.length === 0 ? (
         <li className='anime--error'>
-          No hay ningún anime que coincida {props.searchFetch} 😔
+          No hay ningún anime que coincida con {props.searchFetch} 😔
         </li>
       ) : (
         renderAnimeList


### PR DESCRIPTION
Ha cambiado el modo de llamar al 'id' en la 'key' de los \<li\>, que estaba mal. También las 'props' que le pasábamos a 'AnimeCard' y la ruta para llegar al 'title' que pasa de ser: 'props.anime.title', que no existía a 'props.anime.titles.title' que es la ruta correcta a la propiedad del objeto que nos interesa.
Además se ha añadido una funcionalidad de ejemplo a los botones de: 'Favorite, Watched y Pending', para ver si la ejecutaba al hacer 'click', sacando los mismos de la etiqueta 'Link', pues sino te llevaba al enlace.